### PR TITLE
feat: add portal teleportation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ SRCS =  $(SRC_DIR)main.c \
                 $(PAR_DIR)extract_colors.c \
                 $(PAR_DIR)parse_elements.c \
                 $(PAR_DIR)line_utils.c \
+                $(SRC_DIR)portals.c \
                 $(SRC_DIR)raycasting_utils.c \
                 $(SRC_DIR)minimap_background.c \
                 $(SRC_DIR)minimap.c \

--- a/headers/cub3d.h
+++ b/headers/cub3d.h
@@ -88,6 +88,20 @@ typedef struct s_textures
 	int		color_f[3];
 }       t_textures;
 
+typedef struct s_vec
+{
+        double  x;
+        double  y;
+}       t_vec;
+
+typedef struct s_portal
+{
+        t_vec   pos;
+        double  angle;
+        int             id;
+}       t_portal;
+
+
 typedef struct s_ray
 {
         double  camera;
@@ -103,10 +117,12 @@ typedef struct s_ray
         double  side_dist_y;
         int             map_x;
         int             map_y;
+        double  wall_hit_x;
+        double  wall_hit_y;
         int             draw_start;
         int             draw_end;
         double          perp_dist;
-	int             line_height;
+        int             line_height;
 }	t_ray;
 
 typedef struct s_data
@@ -145,6 +161,7 @@ typedef struct s_game
         int                     state;
         t_data          data;
         t_player        player;
+        t_portal        portals[2];
 }                               t_game;
 
 int             destroy_display(t_game *game, char *str, int error);
@@ -187,5 +204,11 @@ char    *get_next_line(int fd);
 /* UTILS */
 void    free_tab(char **tab);
 
-#endif
 
+/* PORTALS */
+void    cast_ray(t_game *game, t_ray *ray);
+void    transform_through_portal(t_vec hit_pos, double ray_dir,
+                t_portal in, t_portal out, t_vec *new_pos, double *new_dir);
+void    init_portals(t_game *game);
+
+#endif

--- a/maps/portal.cub
+++ b/maps/portal.cub
@@ -1,0 +1,13 @@
+NO textures/wolfenstein/purple_stone.xpm
+SO textures/wolfenstein/red_brick.xpm
+WE textures/wolfenstein/grey_stone.xpm
+EA textures/wolfenstein/wood.xpm
+
+F 17,38,64
+C 218,234,235
+
+111111
+102301
+100001
+100001
+111111

--- a/src/main.c
+++ b/src/main.c
@@ -81,7 +81,8 @@ int	main(int ac, char **av)
 	destroy_display(&game,
 	"Error\ncan't generate window\n", 1);
 	load_textures(&game);
-	create_map(&game);
-	mlx_loop(game.data.mlx);
+        create_map(&game);
+        init_portals(&game);
+        mlx_loop(game.data.mlx);
 	return (0);
 }

--- a/src/parsing/parse_map.c
+++ b/src/parsing/parse_map.c
@@ -135,12 +135,13 @@ int	check_char(char **map)
 		x = 0;
 		while (map[y][x])
 		{
-			if (white_space(map[y][x]) || map[y][x] == '0' || map[y][x] == '1'
-				|| map[y][x] == 'E' || map[y][x] == 'N' || map[y][x] == 'S' ||
-					map[y][x] == 'W')
-				x++;
-			else
-				return (1);
+                        if (white_space(map[y][x]) || map[y][x] == '0' || map[y][x] == '1'
+                                || map[y][x] == '2' || map[y][x] == '3'
+                                || map[y][x] == 'E' || map[y][x] == 'N' || map[y][x] == 'S' ||
+                                        map[y][x] == 'W')
+                                x++;
+                        else
+                                return (1);
 		}
 		y++;
 	}

--- a/src/portals.c
+++ b/src/portals.c
@@ -1,0 +1,134 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   portals.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   Created: 2025/08/05 00:00:00 by ChatGPT           #+#    #+#             */
+/*   Updated: 2025/08/05 00:00:00 by ChatGPT          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../headers/cub3d.h"
+#include <math.h>
+
+#define MAX_PORTAL_DEPTH 5
+
+void    set_directions(t_player *player, t_ray *r);
+void    ft_dda(t_game *game, t_ray *ray);
+
+static t_vec rotate(t_vec v, double angle)
+{
+    t_vec r;
+
+    r.x = v.x * cos(angle) - v.y * sin(angle);
+    r.y = v.x * sin(angle) + v.y * cos(angle);
+    return (r);
+}
+
+void    transform_through_portal(t_vec hit_pos, double ray_dir,
+                t_portal in, t_portal out, t_vec *new_pos, double *new_dir)
+{
+    t_vec offset;
+
+    offset.x = hit_pos.x - in.pos.x;
+    offset.y = hit_pos.y - in.pos.y;
+    offset = rotate(offset, -in.angle);
+    offset = rotate(offset, out.angle);
+    new_pos->x = out.pos.x + offset.x;
+    new_pos->y = out.pos.y + offset.y;
+    *new_dir = ray_dir + (out.angle - in.angle);
+}
+
+void    init_portals(t_game *game)
+{
+    int y;
+    int x;
+
+    y = 0;
+    while (game->map[y])
+    {
+        x = 0;
+        while (game->map[y][x])
+        {
+            if (game->map[y][x] == '2')
+            {
+                game->portals[0].pos.x = x + 0.5;
+                game->portals[0].pos.y = y + 0.5;
+                game->portals[0].angle = 0;
+                game->portals[0].id = 0;
+            }
+            if (game->map[y][x] == '3')
+            {
+                game->portals[1].pos.x = x + 0.5;
+                game->portals[1].pos.y = y + 0.5;
+                game->portals[1].angle = 0;
+                game->portals[1].id = 1;
+            }
+            x++;
+        }
+        y++;
+    }
+}
+
+void    cast_ray(t_game *game, t_ray *ray)
+{
+    t_player    p;
+    double      total_dist;
+    double      dist;
+    int         depth;
+    char        cell;
+    t_vec       new_pos;
+    double      new_dir;
+
+    p = game->player;
+    p.dir_x = ray->dir_x;
+    p.dir_y = ray->dir_y;
+    total_dist = 0.0;
+    depth = 0;
+    while (depth < MAX_PORTAL_DEPTH)
+    {
+        set_directions(&p, ray);
+        ft_dda(game, ray);
+        if (ray->side == 0)
+            dist = ray->side_dist_x - ray->delta_dist_x;
+        else
+            dist = ray->side_dist_y - ray->delta_dist_y;
+        total_dist += dist;
+        ray->wall_hit_x = p.pos_x + dist * ray->dir_x;
+        ray->wall_hit_y = p.pos_y + dist * ray->dir_y;
+        if (ray->map_x < 0 || ray->map_x >= game->width
+            || ray->map_y < 0 || ray->map_y >= game->height)
+            break ;
+        cell = game->map[ray->map_y][ray->map_x];
+        if (cell == '2' || cell == '3')
+        {
+            transform_through_portal((t_vec){ray->wall_hit_x, ray->wall_hit_y},
+                    atan2(ray->dir_y, ray->dir_x),
+                    game->portals[cell == '2' ? 0 : 1],
+                    game->portals[cell == '2' ? 1 : 0],
+                    &new_pos, &new_dir);
+            p.pos_x = new_pos.x;
+            p.pos_y = new_pos.y;
+            ray->dir_x = cos(new_dir);
+            ray->dir_y = sin(new_dir);
+            ray->delta_dist_x = ray->dir_x == 0 ? 1e30 : fabs(1 / ray->dir_x);
+            ray->delta_dist_y = ray->dir_y == 0 ? 1e30 : fabs(1 / ray->dir_y);
+            depth++;
+            continue ;
+        }
+        break ;
+    }
+    ray->perp_dist = total_dist;
+    if (ray->perp_dist <= 0.001)
+        ray->perp_dist = 0.001;
+    ray->line_height = (int)(game->data.win_height / ray->perp_dist);
+    if (ray->line_height > game->data.win_height * 2)
+        ray->line_height = game->data.win_height * 2;
+    ray->draw_start = -ray->line_height / 2 + game->data.win_height / 2;
+    if (ray->draw_start < 0)
+        ray->draw_start = 0;
+    ray->draw_end = ray->line_height / 2 + game->data.win_height / 2;
+    if (ray->draw_end >= game->data.win_height)
+        ray->draw_end = game->data.win_height - 1;
+}
+

--- a/src/raycasting.c
+++ b/src/raycasting.c
@@ -22,9 +22,6 @@ typedef struct s_tex
     int     tex_y;
 }       t_tex;
 
-void    set_directions(t_player *player, t_ray *r);
-void    ft_dda(t_game *game, t_ray *ray);
-void    calculate_wall_params(t_game *game, t_ray *ray);
 void    set_deltas(t_game *game, t_ray *ray, int x);
 
 static t_img    *select_texture(t_game *game, t_ray *ray)
@@ -65,9 +62,9 @@ static void init_tex(t_game *game, t_ray *ray, t_img **tex, t_tex *t)
 {
     *tex = select_texture(game, ray);
     if (ray->side == 0)
-        t->wall_x = game->player.pos_y + ray->perp_dist * ray->dir_y;
+        t->wall_x = ray->wall_hit_y;
     else
-        t->wall_x = game->player.pos_x + ray->perp_dist * ray->dir_x;
+        t->wall_x = ray->wall_hit_x;
     t->wall_x -= floor(t->wall_x);
     t->tex_x = (int)(t->wall_x * (*tex)->width);
     if (ray->side == 0 && ray->dir_x > 0)
@@ -112,9 +109,7 @@ void    raycasting(t_game *game)
     while (++x < game->data.win_width)
     {
         set_deltas(game, &ray, x);
-        set_directions(&game->player, &ray);
-        ft_dda(game, &ray);
-        calculate_wall_params(game, &ray);
+        cast_ray(game, &ray);
         draw_wall(game, &ray, x);
     }
 }

--- a/src/raycasting_utils.c
+++ b/src/raycasting_utils.c
@@ -68,7 +68,7 @@ void    ft_dda(t_game *game, t_ray *ray)
         if (ray->map_x < 0 || ray->map_x >= game->width
             || ray->map_y < 0 || ray->map_y >= game->height)
             ray->hit = 1;
-        else if (game->map[ray->map_y][ray->map_x] == '1')
+        else if (game->map[ray->map_y][ray->map_x] != '0')
             ray->hit = 1;
     }
 }


### PR DESCRIPTION
## Summary
- add portal structures and ray teleportation logic
- support portal tiles in ray casting and map parsing
- include example map using entry and exit portals

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68912dd7e0c4832a95659b5ec3106735